### PR TITLE
Add functioning patient phone editing and query controls

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -96,7 +96,8 @@ $conn->query("
     CREATE TABLE IF NOT EXISTS patients (
         id INT AUTO_INCREMENT PRIMARY KEY,
         name VARCHAR(100) NOT NULL,
-        identity_number VARCHAR(20) NOT NULL UNIQUE
+        identity_number VARCHAR(20) NOT NULL UNIQUE,
+        phone VARCHAR(20) DEFAULT NULL
     ) ENGINE=InnoDB CHARSET=utf8mb4
 ");
 
@@ -158,11 +159,12 @@ $conn->query("
 
 
 // ==== 5. دوال مساعدة لإدارة المرضى والأطباء (مراجعة: التحقق من المدخلات) ====
-function get_or_add_patient($conn, $name, $ident)
+function get_or_add_patient($conn, $name, $ident, $phone = null)
 {
     // تطهير المدخلات قبل استخدامها في الاستعلام
     $name = trim($name);
     $ident = trim($ident);
+    $phone = trim($phone ?? '');
 
     if (empty($name) || empty($ident)) {
         return false; // يجب أن تكون البيانات غير فارغة
@@ -184,12 +186,12 @@ function get_or_add_patient($conn, $name, $ident)
     }
     $stmt->close();
 
-    $stmt = $conn->prepare("INSERT INTO patients (name, identity_number) VALUES (?, ?)");
+    $stmt = $conn->prepare("INSERT INTO patients (name, identity_number, phone) VALUES (?, ?, ?)");
     if (!$stmt) {
         error_log("Prepare failed: (" . $conn->errno . ") " . $conn->error);
         return false;
     }
-    $stmt->bind_param("ss", $name, $ident);
+    $stmt->bind_param("sss", $name, $ident, $phone);
     $stmt->execute();
     $pid = $stmt->insert_id;
     $stmt->close();
@@ -391,14 +393,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
         case 'add_patient':
             $pname = filter_input(INPUT_POST, 'patient_name', FILTER_SANITIZE_STRING);
             $pident = filter_input(INPUT_POST, 'identity_number', FILTER_SANITIZE_STRING);
+            $pphone = filter_input(INPUT_POST, 'phone', FILTER_SANITIZE_STRING);
+            $pphone = filter_input(INPUT_POST, 'phone', FILTER_SANITIZE_STRING);
+            $pphone = filter_input(INPUT_POST, 'phone', FILTER_SANITIZE_STRING);
 
             if (empty($pname) || empty($pident)) {
                 echo json_encode(['success' => false, 'message' => 'أدخل اسم المريض ورقم الهوية.']);
                 exit;
             }
-            $pid = get_or_add_patient($conn, $pname, $pident);
+            $pid = get_or_add_patient($conn, $pname, $pident, $pphone);
             if ($pid) {
-                $row = $conn->query("SELECT id, name, identity_number FROM patients WHERE id=$pid")->fetch_assoc();
+                $row = $conn->query("SELECT id, name, identity_number, phone FROM patients WHERE id=$pid")->fetch_assoc();
                 echo json_encode(['success' => true, 'patient' => $row, 'stats' => get_dashboard_stats($conn)]);
             } else {
                 echo json_encode(['success' => false, 'message' => 'حدث خطأ أثناء إضافة/جلب المريض.']);
@@ -414,16 +419,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
                 echo json_encode(['success' => false, 'message' => 'بيانات المريض غير صحيحة.']);
                 exit;
             }
-            $stmt = $conn->prepare("UPDATE patients SET name=?, identity_number=? WHERE id=?");
+            $stmt = $conn->prepare("UPDATE patients SET name=?, identity_number=?, phone=? WHERE id=?");
             if (!$stmt) {
                 error_log("Prepare failed (edit_patient): (" . $conn->errno . ") " . $conn->error);
                 echo json_encode(['success' => false, 'message' => 'خطأ في قاعدة البيانات.']);
                 exit;
             }
-            $stmt->bind_param("ssi", $pname, $pident, $pid);
+            $stmt->bind_param("sssi", $pname, $pident, $pphone, $pid);
             $stmt->execute();
             $stmt->close();
-            $row = $conn->query("SELECT id, name, identity_number FROM patients WHERE id=$pid")->fetch_assoc();
+            $row = $conn->query("SELECT id, name, identity_number, phone FROM patients WHERE id=$pid")->fetch_assoc();
             echo json_encode(['success' => true, 'patient' => $row, 'stats' => get_dashboard_stats($conn)]);
             break;
 
@@ -445,7 +450,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
 
         case 'fetch_all_patients': // إجراء جديد لجلب قائمة المرضى
             $patients_list = [];
-            $res = $conn->query("SELECT id, name, identity_number FROM patients ORDER BY name ASC");
+            $res = $conn->query("SELECT id, name, identity_number, phone FROM patients ORDER BY name ASC");
             while ($row = $res->fetch_assoc()) {
                 $patients_list[] = $row;
             }
@@ -461,11 +466,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
             if ($patient_select_type === 'manual') {
                 $pm_name = filter_input(INPUT_POST, 'patient_manual_name', FILTER_SANITIZE_STRING);
                 $pm_id = filter_input(INPUT_POST, 'patient_manual_id', FILTER_SANITIZE_STRING);
+                $pm_phone = filter_input(INPUT_POST, 'patient_manual_phone', FILTER_SANITIZE_STRING);
                 if (empty($pm_name) || empty($pm_id)) {
                     echo json_encode(['success' => false, 'message' => 'يجب إدخال اسم المريض ورقم هويته يدوياً.']);
                     exit;
                 }
-                $pid = get_or_add_patient($conn, $pm_name, $pm_id);
+                $pid = get_or_add_patient($conn, $pm_name, $pm_id, $pm_phone);
             } else {
                 $pid = filter_input(INPUT_POST, 'patient_select', FILTER_VALIDATE_INT);
             }
@@ -996,7 +1002,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
                 SELECT sl.id, sl.service_code, sl.issue_date, sl.start_date, sl.end_date, sl.days_count,
                        sl.is_companion, sl.companion_name, sl.companion_relation,
                        sl.is_paid, sl.payment_amount,
-                       d.name AS doctor_name, d.title AS doctor_title
+                       d.name AS doctor_name, d.title AS doctor_title, d.note AS doctor_note
                 FROM sick_leaves sl
                 JOIN doctors d ON sl.doctor_id = d.id
                 WHERE sl.patient_id = ? AND sl.is_deleted = 0
@@ -1060,10 +1066,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
 
             $all_queries = [];
             $res_queries = $conn->query("SELECT lq.id AS qid, lq.leave_id, sl.service_code, p.name AS patient_name, p.identity_number,
+                                 d.name AS doctor_name, d.note AS doctor_note,
                                  DATE_FORMAT(lq.queried_at, '%Y-%m-%d %r') AS queried_at
                           FROM leave_queries lq
                           JOIN sick_leaves sl ON lq.leave_id=sl.id AND sl.is_deleted=0
                           JOIN patients p ON sl.patient_id=p.id
+                          JOIN doctors d ON sl.doctor_id=d.id
                           ORDER BY lq.queried_at DESC");
             if ($res_queries) {
                 while ($row = $res_queries->fetch_assoc()) {
@@ -1195,10 +1203,12 @@ if ($res) {
 // ==== 11. جلب سجلات الاستعلامات للإجازات النشطة (للجدول الفرعي) ====
 $queries = [];
 $res = $conn->query("SELECT lq.id AS qid, lq.leave_id, sl.service_code, p.name AS patient_name, p.identity_number,
+                             d.name AS doctor_name, d.note AS doctor_note,
                              DATE_FORMAT(lq.queried_at, '%Y-%m-%d %r') AS queried_at
                       FROM leave_queries lq
                       JOIN sick_leaves sl ON lq.leave_id=sl.id AND sl.is_deleted=0
                       JOIN patients p ON sl.patient_id=p.id
+                      JOIN doctors d ON sl.doctor_id=d.id
                       ORDER BY lq.queried_at DESC");
 if ($res) {
     while ($row = $res->fetch_assoc()) {
@@ -1983,7 +1993,7 @@ $conn->close();
                 <div class="col-md-6">
                     <label for="patient_select">ابحث عن مريض</label>
                     <div class="input-group mb-1">
-                        <input type="text" id="searchPatient" class="form-control" placeholder="ابحث بالاسم أو الهوية">
+                        <input type="text" id="searchPatient" class="form-control" placeholder="ابحث بالاسم أو الهوية أو الهاتف">
                         <button class="btn btn-primary" type="button" id="btn-search-patient"><i
                                 class="bi bi-search"></i> بحث</button>
                     </div>
@@ -1991,7 +2001,8 @@ $conn->close();
                         <option value="">اختر مريضًا</option>
                         <?php foreach ($patients as $p): ?>
                             <option value="<?= $p['id'] ?>" data-name="<?= htmlspecialchars(strtolower($p['name'])) ?>"
-                                data-identity="<?= htmlspecialchars(strtolower($p['identity_number'])) ?>">
+                                data-identity="<?= htmlspecialchars(strtolower($p['identity_number'])) ?>"
+                                data-phone="<?= htmlspecialchars(strtolower($p['phone'] ?? '')) ?>">
                                 <?= htmlspecialchars($p['name'] . ' (' . $p['identity_number'] . ')') ?>
                             </option>
                         <?php endforeach; ?>
@@ -2002,6 +2013,8 @@ $conn->close();
                         class="form-control mt-2 hidden-field" placeholder="اسم المريض الجديد">
                     <input type="text" name="patient_manual_id" id="patient_manual_id"
                         class="form-control mt-1 hidden-field" placeholder="رقم الهوية الجديد">
+                    <input type="text" name="patient_manual_phone" id="patient_manual_phone"
+                        class="form-control mt-1 hidden-field" placeholder="رقم الهاتف الجديد">
                     <div class="invalid-feedback">أدخل اسم المريض ورقم هويته.</div>
                     <div id="noPatientResult" class="no-results mt-1" style="display:none;">
                         لم يتم العثور على مريض مطابق.
@@ -2143,7 +2156,7 @@ $conn->close();
                 <div class="input-group mb-2">
                     <label for="searchLeaves" class="form-label visually-hidden">بحث</label>
                     <input type="text" id="searchLeaves" class="form-control"
-                        placeholder="ابحث برمز الخدمة أو المريض أو الطبيب">
+                        placeholder="ابحث برمز الخدمة أو المريض أو الطبيب أو الملاحظة">
                     <button class="btn btn-primary" type="button" id="btn-search-leaves"><i class="bi bi-search"></i>
                         بحث</button>
                 </div>
@@ -2205,7 +2218,7 @@ $conn->close();
                                                 class="bi bi-pencil-square"></i> تعديل</button>
                                         <button class="btn btn-danger btn-sm action-btn btn-delete-leave"><i
                                                 class="bi bi-archive-fill"></i> أرشفة</button>
-                                        <button class="btn btn-warning btn-sm action-btn btn-view-queries"><i
+                                        <button class="btn btn-warning btn-sm action-btn btn-view-queries" data-leave-id="<?= $lv['id'] ?>"><i
                                                 class="bi bi-journal-text"></i> استعلامات</button>
                                         <button
                                             class="btn btn-success btn-sm action-btn btn-mark-paid <?= $lv['is_paid'] ? 'd-none' : '' ?>"><i
@@ -2332,7 +2345,7 @@ $conn->close();
                                             <button class="btn btn-danger btn-sm action-btn btn-force-delete-leave"><i
                                                     class="bi bi-x-circle"></i>
                                                 حذف نهائي</button>
-                                            <button class="btn btn-warning btn-sm action-btn btn-view-queries"><i
+                                            <button class="btn btn-warning btn-sm action-btn btn-view-queries" data-leave-id="<?= $lv['id'] ?>"><i
                                                     class="bi bi-journal-text"></i>
                                                 استعلامات</button>
                                         </td>
@@ -2646,7 +2659,7 @@ $conn->close();
                     <div class="input-group mb-2">
                         <label for="searchPatientsTable" class="form-label visually-hidden">بحث</label>
                         <input type="text" id="searchPatientsTable" class="form-control"
-                            placeholder="ابحث بالاسم أو الهوية">
+                            placeholder="ابحث بالاسم أو الهوية أو الهاتف">
                         <button class="btn btn-primary" type="button" id="btn-search-patients"><i
                                 class="bi bi-search"></i> بحث</button>
                     </div>
@@ -2657,6 +2670,7 @@ $conn->close();
                                     <th>رقم</th>
                                     <th>الاسم <i class="bi bi-sort-alpha-down"></i></th>
                                     <th>الهوية</th>
+                                    <th>الهاتف</th>
                                     <th>تحكم</th>
                                 </tr>
                             </thead>
@@ -2666,6 +2680,7 @@ $conn->close();
                                         <td class="row-num"></td>
                                         <td><?= htmlspecialchars($p['name']) ?></td>
                                         <td><?= htmlspecialchars($p['identity_number']) ?></td>
+                                        <td><?= htmlspecialchars($p['phone'] ?? '') ?></td>
                                         <td>
                                             <button class="btn btn-warning btn-sm action-btn btn-edit-patient"><i
                                                     class="bi bi-pencil-square"></i> تعديل</button>
@@ -2676,7 +2691,7 @@ $conn->close();
                                 <?php endforeach; ?>
                                 <?php if (empty($patients)): ?>
                                     <tr class="no-results">
-                                        <td colspan="4">لا يوجد مرضى حاليًا.</td>
+                                        <td colspan="5">لا يوجد مرضى حاليًا.</td>
                                     </tr>
                                 <?php endif; ?>
                             </tbody>
@@ -2685,17 +2700,22 @@ $conn->close();
                     <form class="row g-2 mt-3 needs-validation" id="patientForm" style="display:none;" novalidate>
                         <?= csrf_input(); ?>
                         <input type="hidden" id="patient_form_id" name="patient_id">
-                        <div class="col-md-5">
+                        <div class="col-md-4">
                             <label for="patient_form_name" class="form-label visually-hidden">اسم المريض</label>
                             <input type="text" id="patient_form_name" name="patient_name" class="form-control"
                                 placeholder="اسم المريض" required>
                             <div class="invalid-feedback">أدخل اسم المريض.</div>
                         </div>
-                        <div class="col-md-5">
+                        <div class="col-md-4">
                             <label for="patient_form_identity" class="form-label visually-hidden">رقم الهوية</label>
                             <input type="text" id="patient_form_identity" name="identity_number" class="form-control"
                                 placeholder="رقم الهوية" required>
                             <div class="invalid-feedback">أدخل رقم الهوية.</div>
+                        </div>
+                        <div class="col-md-4">
+                            <label for="patient_form_phone" class="form-label visually-hidden">رقم الهاتف</label>
+                            <input type="text" id="patient_form_phone" name="phone" class="form-control"
+                                placeholder="رقم الهاتف">
                         </div>
                         <div class="col-md-2 d-flex gap-1">
                             <button type="submit" class="btn btn-success-custom w-100"><i class="bi bi-save-fill"></i>
@@ -2836,6 +2856,7 @@ $conn->close();
             const patientSelect = document.getElementById('patient_select');
             const patientManualName = document.getElementById('patient_manual_name');
             const patientManualId = document.getElementById('patient_manual_id');
+            const patientManualPhone = document.getElementById('patient_manual_phone');
             const searchPatientInput = document.getElementById('searchPatient');
             const noPatientResult = document.getElementById('noPatientResult');
 
@@ -2868,6 +2889,7 @@ $conn->close();
 
             const viewQueriesModal = new bootstrap.Modal(document.getElementById('viewQueriesModal'));
             const queriesDetailsContainer = document.getElementById('queriesDetailsContainer');
+            let currentDetailedQueries = [];
 
             const paymentNotifModal = new bootstrap.Modal(document.getElementById('paymentNotifModal'));
             const notifPaymentsList = document.getElementById('notifPayments');
@@ -3234,6 +3256,7 @@ $conn->close();
                         option.textContent = `${p.name} (${p.identity_number})`;
                         option.dataset.name = p.name.toLowerCase();
                         option.dataset.identity = p.identity_number.toLowerCase();
+                        option.dataset.phone = (p.phone || '').toLowerCase();
                         patientSelect.append(option);
                     });
                     if (selectedId) {
@@ -3254,6 +3277,7 @@ $conn->close();
                 <td class="row-num"></td>
                 <td class="cell-patient-name">${htmlspecialchars(p.name)}</td>
                 <td class="cell-patient-identity">${htmlspecialchars(p.identity_number)}</td>
+                <td class="cell-patient-phone">${htmlspecialchars(p.phone || '')}</td>
                 <td>
                     <button class="btn btn-warning btn-sm action-btn btn-edit-patient"><i class="bi bi-pencil-square"></i> تعديل</button>
                     <button class="btn btn-danger btn-sm action-btn btn-delete-patient"><i class="bi bi-trash-fill"></i> حذف</button>
@@ -3382,7 +3406,7 @@ $conn->close();
              */
             function generateQueryRow(q) {
                 return `
-            <tr data-id="${q.qid}" data-leave-id="${q.leave_id}">
+            <tr data-id="${q.qid}" data-leave-id="${q.leave_id}" data-doctor-name="${htmlspecialchars(q.doctor_name || '')}" data-doctor-note="${htmlspecialchars(q.doctor_note || '')}">
                 <td class="row-num"></td>
                 <td class="cell-service">${htmlspecialchars(q.service_code.toUpperCase())}</td>
                 <td class="cell-patient">${htmlspecialchars(q.patient_name)}</td>
@@ -3445,17 +3469,22 @@ $conn->close();
                         if (tableElement.id === 'leavesTable' || tableElement.id === 'archivedTable') {
                             return item.service_code.toLowerCase().includes(searchTerm) ||
                                 item.patient_name.toLowerCase().includes(searchTerm) ||
-                                item.doctor_name.toLowerCase().includes(searchTerm);
+                                item.doctor_name.toLowerCase().includes(searchTerm) ||
+                                (item.doctor_note && item.doctor_note.toLowerCase().includes(searchTerm));
                         } else if (tableElement.id === 'doctorsTable') {
                             return item.name.toLowerCase().includes(searchTerm) ||
-                                item.title.toLowerCase().includes(searchTerm);
+                                item.title.toLowerCase().includes(searchTerm) ||
+                                (item.note && item.note.toLowerCase().includes(searchTerm));
                         } else if (tableElement.id === 'patientsTable') {
                             return item.name.toLowerCase().includes(searchTerm) ||
-                                item.identity_number.toLowerCase().includes(searchTerm);
+                                item.identity_number.toLowerCase().includes(searchTerm) ||
+                                (item.phone && item.phone.toLowerCase().includes(searchTerm));
                         } else if (tableElement.id === 'queriesTable') {
                             return item.service_code.toLowerCase().includes(searchTerm) ||
                                 item.patient_name.toLowerCase().includes(searchTerm) ||
-                                item.identity_number.toLowerCase().includes(searchTerm);
+                                item.identity_number.toLowerCase().includes(searchTerm) ||
+                                (item.doctor_name && item.doctor_name.toLowerCase().includes(searchTerm)) ||
+                                (item.doctor_note && item.doctor_note.toLowerCase().includes(searchTerm));
                         } else if (tableElement.id === 'paymentsTable') {
                             return item.name.toLowerCase().includes(searchTerm);
                         }
@@ -3748,6 +3777,7 @@ $conn->close();
                 const isManual = patientSelect.value === 'manual';
                 patientManualName.classList.toggle('hidden-field', !isManual);
                 patientManualId.classList.toggle('hidden-field', !isManual);
+                patientManualPhone.classList.toggle('hidden-field', !isManual);
                 patientManualName.toggleAttribute('required', isManual);
                 patientManualId.toggleAttribute('required', isManual);
                 searchPatientInput.classList.toggle('hidden-field', isManual);
@@ -3759,6 +3789,7 @@ $conn->close();
                     patientManualId.value = '';
                     patientManualName.classList.remove('is-invalid');
                     patientManualId.classList.remove('is-invalid');
+                    patientManualPhone.value = '';
                 }
             }
 
@@ -3769,7 +3800,8 @@ $conn->close();
                 patientSelect.querySelectorAll('option:not([value="manual"]):not([value=""])').forEach(option => {
                     const patientName = option.dataset.name;
                     const patientIdentity = option.dataset.identity;
-                    const matches = patientName.includes(searchTerm) || patientIdentity.includes(searchTerm);
+                    const patientPhone = option.dataset.phone || '';
+                    const matches = patientName.includes(searchTerm) || patientIdentity.includes(searchTerm) || patientPhone.includes(searchTerm);
                     option.style.display = matches ? '' : 'none';
                     if (matches) found = true;
                 });
@@ -3950,6 +3982,7 @@ $conn->close();
             const patientFormId = document.getElementById('patient_form_id');
             const patientFormName = document.getElementById('patient_form_name');
             const patientFormIdentity = document.getElementById('patient_form_identity');
+            const patientFormPhone = document.getElementById('patient_form_phone');
 
             document.getElementById('btn-show-add-patient').addEventListener('click', () => {
                 clearForm(patientForm);
@@ -3988,10 +4021,12 @@ $conn->close();
                     const patientId = row.dataset.id;
                     const patientName = row.querySelector('.cell-patient-name').textContent;
                     const patientIdentity = row.querySelector('.cell-patient-identity').textContent;
+                    const patientPhone = row.querySelector('.cell-patient-phone').textContent;
 
                     patientFormId.value = patientId;
                     patientFormName.value = patientName;
                     patientFormIdentity.value = patientIdentity;
+                    patientFormPhone.value = patientPhone;
                     patientForm.style.display = 'flex'; // إظهار النموذج للتعديل
                 }
             });
@@ -4244,24 +4279,8 @@ $conn->close();
                         leave_id: leaveId
                     });
                     if (result.success) {
-                        if (result.queries.length > 0) {
-                            queriesDetailsContainer.innerHTML = `
-                        <ul class="list-group" id="detailedQueriesList"></ul>
-                    `;
-                            const detailedQueriesList = document.getElementById('detailedQueriesList');
-                            result.queries.forEach(q => {
-                                const li = document.createElement('li');
-                                li.className = 'list-group-item d-flex justify-content-between align-items-center';
-                                li.setAttribute('data-id', q.id);
-                                li.innerHTML = `
-                            <span>${htmlspecialchars(q.queried_at)}</span>
-                            <button class="btn btn-danger btn-sm btn-delete-detail-query" data-id="${q.id}"><i class="bi bi-trash-fill"></i> حذف</button>
-                        `;
-                                detailedQueriesList.appendChild(li);
-                            });
-                        } else {
-                            queriesDetailsContainer.innerHTML = '<p class="text-center">لا توجد سجلات استعلام لهذه الإجازة.</p>';
-                        }
+                        currentDetailedQueries = result.queries;
+                        renderDetailedQueries('desc');
                     } else {
                         queriesDetailsContainer.innerHTML = `<p class="text-center text-danger">${result.message}</p>`;
                     }
@@ -4290,6 +4309,27 @@ $conn->close();
                 }
             });
 
+            // تحديد إجازة كمدفوعة من الجدول الرئيسي
+            leavesTable.addEventListener('click', (e) => {
+                if (e.target.classList.contains('btn-mark-paid')) {
+                    const row = e.target.closest('tr');
+                    const leaveId = e.target.dataset.leaveId || row.dataset.id;
+                    const amount = e.target.dataset.amount;
+                    confirmMessage.textContent = `هل أنت متأكد من تحديد هذه الإجازة كمدفوعة بمبلغ ${amount}?`;
+                    currentConfirmAction = async () => {
+                        const result = await sendAjaxRequest('mark_leave_paid', { leave_id: leaveId, amount: amount });
+                        if (result.success) {
+                            showToast(result.message, 'success');
+                            row.querySelector('.cell-is-paid').innerHTML = '<span class="badge bg-success">نعم</span>';
+                            row.querySelector('.cell-amount').textContent = parseFloat(amount).toFixed(2);
+                            e.target.classList.add('d-none');
+                            updateStats(result.stats);
+                        }
+                    };
+                    confirmModal.show();
+                }
+            });
+
             // حذف استعلام من نافذة تفاصيل الاستعلام
             queriesDetailsContainer.addEventListener('click', (e) => {
                 if (e.target.classList.contains('btn-delete-detail-query')) {
@@ -4301,8 +4341,8 @@ $conn->close();
                         });
                         if (result.success) {
                             showToast(result.message, 'success');
-                            // إزالة الصف من قائمة التفاصيل
-                            e.target.closest('li').remove();
+                            currentDetailedQueries = currentDetailedQueries.filter(q => q.id != queryId);
+                            renderDetailedQueries('desc');
                             // تحديث عدد الاستعلامات في جدول الإجازات الرئيسية
                             const leaveRow = leavesTable.querySelector(`tr[data-id="${currentConfirmId}"]`);
                             if (leaveRow) {
@@ -4686,9 +4726,29 @@ $conn->close();
                 confirmModal.show();
             });
 
-            // عرض تفاصيل إجازة من سجل الاستعلامات
+            // حذف استعلام مباشرة من جدول الاستعلامات
             queriesTable.addEventListener('click', async (e) => {
-                if (e.target.classList.contains('btn-view-leave-from-query')) {
+                if (e.target.classList.contains('btn-delete-query')) {
+                    const row = e.target.closest('tr');
+                    const qid = row.dataset.id;
+                    const leaveId = row.dataset.leaveId;
+                    confirmMessage.textContent = 'هل أنت متأكد من حذف سجل الاستعلام هذا؟';
+                    currentConfirmAction = async () => {
+                        const result = await sendAjaxRequest('delete_query', { query_id: qid });
+                        if (result.success) {
+                            showToast(result.message, 'success');
+                            row.remove();
+                            currentTableData.queries = currentTableData.queries.filter(q => q.qid != qid);
+                            updateRowNumbers(queriesTable);
+                            const leaveRow = leavesTable.querySelector(`tr[data-id="${leaveId}"]`);
+                            if (leaveRow) {
+                                const c = leaveRow.querySelector('.cell-queries-count');
+                                if (c) c.textContent = Math.max(0, parseInt(c.textContent) - 1);
+                            }
+                        }
+                    };
+                    confirmModal.show();
+                } else if (e.target.classList.contains('btn-view-leave-from-query')) {
                     const leaveId = e.target.dataset.leaveId;
                     showLoading();
                     const result = await sendAjaxRequest('fetch_leave_details', { leave_id: leaveId });
@@ -4816,7 +4876,7 @@ $conn->close();
             });
 
             // دالة لإنشاء مودال لعرض إجازات المريض إذا لم يكن موجودًا
-            function createPatientLeavesModal() {
+function createPatientLeavesModal() {
                 const modalHtml = `
             <div class="modal fade" id="viewPatientLeavesModal" tabindex="-1" aria-hidden="true">
                 <div class="modal-dialog modal-lg modal-dialog-centered">
@@ -4836,6 +4896,28 @@ $conn->close();
         `;
                 document.body.insertAdjacentHTML('beforeend', modalHtml);
                 return document.getElementById('viewPatientLeavesModal');
+}
+
+            function renderDetailedQueries(order = 'desc') {
+                if (!currentDetailedQueries) return;
+                if (currentDetailedQueries.length === 0) {
+                    queriesDetailsContainer.innerHTML = '<p class="text-center">لا توجد سجلات استعلام لهذه الإجازة.</p>';
+                    return;
+                }
+                const sorted = [...currentDetailedQueries].sort((a, b) => {
+                    const da = new Date(a.queried_at);
+                    const db = new Date(b.queried_at);
+                    return order === 'asc' ? da - db : db - da;
+                });
+                let html = '<ul class="list-group" id="detailedQueriesList">';
+                html += sorted.map(q => `
+                    <li class="list-group-item d-flex justify-content-between align-items-center" data-id="${q.id}">
+                        <span>${htmlspecialchars(q.queried_at)}</span>
+                        <button class="btn btn-danger btn-sm btn-delete-detail-query" data-id="${q.id}"><i class="bi bi-trash-fill"></i> حذف</button>
+                    </li>
+                `).join('');
+                html += '</ul>';
+                queriesDetailsContainer.innerHTML = html;
             }
 
             // ====== وظائف الطباعة والتصدير ======
@@ -4929,18 +5011,31 @@ $conn->close();
                 };
             });
 
-            currentTableData.patients = Array.from(patientsTable.querySelectorAll('tbody tr:not(.no-results)')).map(row => {
+           currentTableData.patients = Array.from(patientsTable.querySelectorAll('tbody tr:not(.no-results)')).map(row => {
                 return {
                     id: row.dataset.id,
                     name: row.cells[1].textContent,
                     identity_number: row.cells[2].textContent,
+                    phone: row.cells[3].textContent,
                 };
+            });
+
+            document.getElementById('sortQueriesDetailNewest').addEventListener('click', () => {
+                renderDetailedQueries('desc');
+            });
+            document.getElementById('sortQueriesDetailOldest').addEventListener('click', () => {
+                renderDetailedQueries('asc');
+            });
+            document.getElementById('sortQueriesDetailReset').addEventListener('click', () => {
+                renderDetailedQueries('desc');
             });
 
             currentTableData.queries = Array.from(queriesTable.querySelectorAll('tbody tr:not(.no-results)')).map(row => {
                 return {
                     qid: row.dataset.id,
                     leave_id: row.dataset.leaveId,
+                    doctor_name: row.dataset.doctorName,
+                    doctor_note: row.dataset.doctorNote,
                     service_code: row.cells[1].textContent,
                     patient_name: row.cells[2].textContent,
                     identity_number: row.cells[3].textContent,

--- a/init_tables.php
+++ b/init_tables.php
@@ -60,7 +60,8 @@ function resetAndCreateTables(array $config, string $adminUsername, string $admi
 CREATE TABLE `patients` (
   `id`             INT AUTO_INCREMENT PRIMARY KEY,
   `name`           VARCHAR(100) NOT NULL,
-  `identity_number` VARCHAR(20) NOT NULL UNIQUE
+  `identity_number` VARCHAR(20) NOT NULL UNIQUE,
+  `phone`           VARCHAR(20) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 SQL
     );


### PR DESCRIPTION
## Summary
- fix editing of patients and doctors with phone support
- enable deletion of individual queries and mark leaves paid
- allow searching queries by doctor note/name
- add missing leave IDs to queries buttons
- add sorting for query details modal

## Testing
- `php -l admin.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68546d780e108323b7a4dd60f4757ac6